### PR TITLE
fix: 修复 jq 1.7 下 DNS strategy 检测语法错误

### DIFF
--- a/singbox.sh
+++ b/singbox.sh
@@ -2304,7 +2304,7 @@ _check_and_fix_dns() {
     
     local has_dns=$(jq 'has("dns")' "$CONFIG_FILE" 2>/dev/null)
     local has_auto_detect=$(jq 'try .route.auto_detect_interface catch false' "$CONFIG_FILE" 2>/dev/null)
-    local dns_strategy=$(jq -r 'try .dns.strategy // "" catch ""' "$CONFIG_FILE" 2>/dev/null)
+    local dns_strategy=$(jq -r '.dns.strategy // ""' "$CONFIG_FILE" 2>/dev/null)
     local needs_restart=false
     
     if [ "$has_dns" == "false" ] || [ "$has_auto_detect" == "true" ] || [ -z "$dns_strategy" ]; then


### PR DESCRIPTION
## 修复内容

修复 `jq 1.7` 下 DNS strategy 检测表达式语法错误的问题。

原表达式：

```bash
jq -r 'try .dns.strategy // "" catch ""'
```

在 jq 1.7 中会报错：

```text
jq: error: syntax error, unexpected catch
```

由于脚本隐藏了 jq 错误输出，`dns_strategy` 会变成空字符串，从而每次启动都触发：

```text
检测到 DNS/路由配置需要兼容性修复，正在自动处理...
```

修改为：

```bash
jq -r '.dns.strategy // ""'
```

该写法可以正确兼容 jq 1.7。

## 测试

已确认：

```bash
jq --version
# jq-1.7

jq -r '.dns.strategy // ""' config.json
# prefer_ipv4
```

Fixes #12